### PR TITLE
Implement suggestions

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,4 +9,12 @@ optimizer_runs = 1000000
 bytecode_hash = "none"
 
 [fuzz]
-runs = 16384
+# runs = 16384
+runs = 256
+
+
+[rpc_endpoints]
+mainnet = "${ETHEREUM_RPC_URL}"
+
+[etherscan]
+mainnet = { key = "${ETHERSCAN_API_KEY}" }

--- a/src/BoringBatchable.sol
+++ b/src/BoringBatchable.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// solhint-disable avoid-low-level-calls
+// solhint-disable no-inline-assembly
+
+/**
+ * Base: https://github.com/boringcrypto/BoringSolidity/blob/78f4817d9c0d95fe9c45cd42e307ccd22cf5f4fc/contracts/BoringBatchable.sol
+ * modified:
+ * - replace external IERC20 import with local IERC20Permit interface
+ */
+
+// WARNING!!!
+// Combining BoringBatchable with msg.value can cause double spending issues
+// https://www.paradigm.xyz/2021/08/two-rights-might-make-a-wrong/
+
+interface IERC20Permit {
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+}
+
+contract BaseBoringBatchable {
+    error BatchError(bytes innerError);
+
+    /// @dev Helper function to extract a useful revert message from a failed call.
+    /// If the returned data is malformed or not correctly abi encoded then this call can fail itself.
+    function _getRevertMsg(bytes memory _returnData) internal pure{
+        // If the _res length is less than 68, then
+        // the transaction failed with custom error or silently (without a revert message)
+        if (_returnData.length < 68) revert BatchError(_returnData);
+
+        assembly {
+            // Slice the sighash.
+            _returnData := add(_returnData, 0x04)
+        }
+        revert(abi.decode(_returnData, (string))); // All that remains is the revert string
+    }
+
+    /// @notice Allows batched call to self (this contract).
+    /// @param calls An array of inputs for each call.
+    /// @param revertOnFail If True then reverts after a failed call and stops doing further calls.
+    // F1: External is ok here because this is the batch function, adding it to a batch makes no sense
+    // F2: Calls in the batch may be payable, delegatecall operates in the same context, so each call in the batch has access to msg.value
+    // C3: The length of the loop is fully under user control, so can't be exploited
+    // C7: Delegatecall is only used on the same contract, so it's safe
+    function batch(bytes[] calldata calls, bool revertOnFail) external payable {
+        for (uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory result) = address(this).delegatecall(calls[i]);
+            if (!success && revertOnFail) {
+                _getRevertMsg(result);
+            }
+        }
+    }
+}
+
+// to set Goo approvals for users to this contract
+contract BoringBatchable is BaseBoringBatchable {
+    /// @notice Call wrapper that performs `ERC20.permit` on `token`.
+    /// Lookup `IERC20.permit`.
+    // F6: Parameters can be used front-run the permit and the user's permit will fail (due to nonce or other revert)
+    //     if part of a batch this could be used to grief once as the second call would not need the permit
+    function permitToken(
+        IERC20Permit token,
+        address from,
+        address to,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, to, amount, deadline, v, r, s);
+    }
+}

--- a/src/BoringBatchable.sol
+++ b/src/BoringBatchable.sol
@@ -15,15 +15,8 @@ pragma solidity ^0.8.0;
 // https://www.paradigm.xyz/2021/08/two-rights-might-make-a-wrong/
 
 interface IERC20Permit {
-    function permit(
-        address owner,
-        address spender,
-        uint256 value,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external;
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external;
 }
 
 contract BaseBoringBatchable {
@@ -31,7 +24,7 @@ contract BaseBoringBatchable {
 
     /// @dev Helper function to extract a useful revert message from a failed call.
     /// If the returned data is malformed or not correctly abi encoded then this call can fail itself.
-    function _getRevertMsg(bytes memory _returnData) internal pure{
+    function _getRevertMsg(bytes memory _returnData) internal pure {
         // If the _res length is less than 68, then
         // the transaction failed with custom error or silently (without a revert message)
         if (_returnData.length < 68) revert BatchError(_returnData);
@@ -75,7 +68,9 @@ contract BoringBatchable is BaseBoringBatchable {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public {
+    )
+        public
+    {
         token.permit(from, to, amount, deadline, v, r, s);
     }
 }

--- a/src/Constants.sol
+++ b/src/Constants.sol
@@ -9,7 +9,6 @@ abstract contract Constants {
 
     error Unauthorized();
     error InvalidArguments();
-    error MismatchedGobbler(uint256 gobblerId);
     error Reentered();
 
     event DepositGobblers(address indexed owner, uint256[] gobblerIds, uint32 sumMultiples);

--- a/src/Constants.sol
+++ b/src/Constants.sol
@@ -2,17 +2,16 @@
 pragma solidity ^0.8.13;
 
 abstract contract Constants {
-    uint256 public constant GOO_SHARES_ID = 0;
-    uint256 public constant GOBBLER_STAKING_ID_START = GOO_SHARES_ID + 1;
     uint256 public constant MIN_GOO_SHARES_INITIAL_MINT = 1e12;
     // solmate prevents us from minting to 0 address
     address internal constant BURN_ADDRESS = address(0xdeaDDeADDEaDdeaDdEAddEADDEAdDeadDEADDEaD);
+    address internal constant LAZY_MINT_ADDRESS = address(0x1);
 
     error Unauthorized();
-    error InvalidStakingId();
-    error MismatchedGobblers();
+    error InvalidArguments();
+    error MismatchedGobbler(uint256 gobblerId);
     error Reentered();
 
-    event DepositGobblers(address indexed owner, uint256 indexed stakingId, uint256[] gobblerIds, uint32 sumMultiples);
+    event DepositGobblers(address indexed owner, uint256[] gobblerIds, uint32 sumMultiples);
     event DepositGoo(address indexed owner, uint256 amount, uint256 shares);
 }

--- a/src/ERC20.sol
+++ b/src/ERC20.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+/**
+ * Base: https://github.com/transmissions11/solmate/blob/62e0943c013a66b2720255e2651450928f4eed7a/src/tokens/ERC20.sol
+ * modified to:
+ * - expose internal `_transfer`
+ * - expose `balanceOf`
+ * - added `_beforeTokenTransfer` hook
+ */
+
+/// @notice Modern and gas efficient ERC20 + EIP-2612 implementation.
+/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC20.sol)
+/// @author Modified from Uniswap (https://github.com/Uniswap/uniswap-v2-core/blob/master/contracts/UniswapV2ERC20.sol)
+/// @dev Do not manually set balances without updating totalSupply, as the sum of all user balances must not exceed it.
+abstract contract ERC20 {
+    /*//////////////////////////////////////////////////////////////
+                                 EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
+    /*//////////////////////////////////////////////////////////////
+                            METADATA STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    string public name;
+
+    string public symbol;
+
+    uint8 public immutable decimals;
+
+    /*//////////////////////////////////////////////////////////////
+                              ERC20 STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 public totalSupply;
+
+    mapping(address => uint256) internal _balanceOf;
+
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    /*//////////////////////////////////////////////////////////////
+                            EIP-2612 STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 internal immutable INITIAL_CHAIN_ID;
+
+    bytes32 internal immutable INITIAL_DOMAIN_SEPARATOR;
+
+    mapping(address => uint256) public nonces;
+
+    /*//////////////////////////////////////////////////////////////
+                               CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(string memory _name, string memory _symbol, uint8 _decimals) {
+        name = _name;
+        symbol = _symbol;
+        decimals = _decimals;
+
+        INITIAL_CHAIN_ID = block.chainid;
+        INITIAL_DOMAIN_SEPARATOR = computeDomainSeparator();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                               ERC20 LOGIC
+    //////////////////////////////////////////////////////////////*/
+    function balanceOf(address account) external virtual returns (uint256) {
+        return _balanceOf[account];
+    }
+
+    function approve(address spender, uint256 amount) public virtual returns (bool) {
+        allowance[msg.sender][spender] = amount;
+
+        emit Approval(msg.sender, spender, amount);
+
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) public virtual returns (bool) {
+        _transfer(msg.sender, to, amount);
+
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public virtual returns (bool) {
+        uint256 allowed = allowance[from][msg.sender]; // Saves gas for limited approvals.
+
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+
+        _transfer(from, to, amount);
+
+        return true;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             EIP-2612 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        public
+        virtual
+    {
+        require(deadline >= block.timestamp, "PERMIT_DEADLINE_EXPIRED");
+
+        // Unchecked because the only math done is incrementing
+        // the owner's nonce which cannot realistically overflow.
+        unchecked {
+            address recoveredAddress = ecrecover(
+                keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        DOMAIN_SEPARATOR(),
+                        keccak256(
+                            abi.encode(
+                                keccak256(
+                                    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+                                ),
+                                owner,
+                                spender,
+                                value,
+                                nonces[owner]++,
+                                deadline
+                            )
+                        )
+                    )
+                ),
+                v,
+                r,
+                s
+            );
+
+            require(recoveredAddress != address(0) && recoveredAddress == owner, "INVALID_SIGNER");
+
+            allowance[recoveredAddress][spender] = value;
+        }
+
+        emit Approval(owner, spender, value);
+    }
+
+    function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
+        return block.chainid == INITIAL_CHAIN_ID ? INITIAL_DOMAIN_SEPARATOR : computeDomainSeparator();
+    }
+
+    function computeDomainSeparator() internal view virtual returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes(name)),
+                keccak256("1"),
+                block.chainid,
+                address(this)
+            )
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        INTERNAL MINT/BURN LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function _mint(address to, uint256 amount) internal virtual {
+        _beforeTokenTransfer(sender, recipient, amount);
+        totalSupply += amount;
+
+        // Cannot overflow because the sum of all user
+        // balances can't exceed the max uint256 value.
+        unchecked {
+            _balanceOf[to] += amount;
+        }
+
+        emit Transfer(address(0), to, amount);
+    }
+
+    function _burn(address from, uint256 amount) internal virtual {
+        _beforeTokenTransfer(sender, recipient, amount);
+        _balanceOf[from] -= amount;
+
+        // Cannot underflow because a user's balance
+        // will never be larger than the total supply.
+        unchecked {
+            totalSupply -= amount;
+        }
+
+        emit Transfer(from, address(0), amount);
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal virtual {
+        _beforeTokenTransfer(sender, recipient, amount);
+        // reverts if not enough balance
+        _balanceOf[from] -= amount;
+
+        // Cannot overflow because the sum of all user
+        // balances can't exceed the max uint256 value.
+        unchecked {
+            _balanceOf[to] += amount;
+        }
+
+        emit Transfer(msg.sender, to, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual {}
+}

--- a/src/ERC20.sol
+++ b/src/ERC20.sol
@@ -164,7 +164,7 @@ abstract contract ERC20 {
     //////////////////////////////////////////////////////////////*/
 
     function _mint(address to, uint256 amount) internal virtual {
-        _beforeTokenTransfer(address(0), to, amount);
+        // _mint is only called from GooStew (not from this ERC20), so we don't need a hook, we manually ensure that everything is up-to-date
         totalSupply += amount;
 
         // Cannot overflow because the sum of all user
@@ -177,7 +177,7 @@ abstract contract ERC20 {
     }
 
     function _burn(address from, uint256 amount) internal virtual {
-        _beforeTokenTransfer(from, address(0), amount);
+        // _burn is only called from GooStew (not from this ERC20), so we don't need a hook, we manually ensure that everything is up-to-date
         _balanceOf[from] -= amount;
 
         // Cannot underflow because a user's balance

--- a/src/ERC20.sol
+++ b/src/ERC20.sol
@@ -164,7 +164,7 @@ abstract contract ERC20 {
     //////////////////////////////////////////////////////////////*/
 
     function _mint(address to, uint256 amount) internal virtual {
-        _beforeTokenTransfer(sender, recipient, amount);
+        _beforeTokenTransfer(address(0), to, amount);
         totalSupply += amount;
 
         // Cannot overflow because the sum of all user
@@ -177,7 +177,7 @@ abstract contract ERC20 {
     }
 
     function _burn(address from, uint256 amount) internal virtual {
-        _beforeTokenTransfer(sender, recipient, amount);
+        _beforeTokenTransfer(from, address(0), amount);
         _balanceOf[from] -= amount;
 
         // Cannot underflow because a user's balance
@@ -190,7 +190,7 @@ abstract contract ERC20 {
     }
 
     function _transfer(address from, address to, uint256 amount) internal virtual {
-        _beforeTokenTransfer(sender, recipient, amount);
+        _beforeTokenTransfer(from, to, amount);
         // reverts if not enough balance
         _balanceOf[from] -= amount;
 

--- a/src/GooStew.sol
+++ b/src/GooStew.sol
@@ -8,13 +8,14 @@ import {toDaysWadUnsafe} from "solmate/utils/SignedWadMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IGobblers} from "./IGobblers.sol";
 import {Constants} from "./Constants.sol";
+import {BoringBatchable} from "./BoringBatchable.sol";
 import {LibGOO} from "./LibGOO.sol";
 import {LibPackedArray} from "./LibPackedArray.sol";
-import {IGobblers} from "./IGobblers.sol";
 import {ERC20} from "./ERC20.sol";
 
-contract GooStew is ERC20, Constants {
+contract GooStew is ERC20, BoringBatchable, Constants {
     using LibString for uint256;
     using LibPackedArray for uint256[];
     using FixedPointMathLib for uint256;

--- a/src/GooStew.sol
+++ b/src/GooStew.sol
@@ -62,7 +62,7 @@ contract GooStew is ERC20, Constants {
         if (_lastUpdate == block.timestamp) return;
 
         (, uint256 rewardsGoo, uint256 rewardsGobblers) = _calculateUpdate();
-        _lastUpdate = block.timestamp; // update can now be set as following functions don't use it anymore
+        _lastUpdate = block.timestamp; // update can now be set as subsequent calls don't use it anymore
 
         // 1. update goo rewards: this updates _sharesPrice
         _totalGoo += rewardsGoo;
@@ -78,7 +78,6 @@ contract GooStew is ERC20, Constants {
             _mint(LAZY_MINT_ADDRESS, mintShares);
             _gobblerSharesPerMultipleIndex += (mintShares * 1e18) / _sumMultiples;
         }
-
     }
 
     function _calculateUpdate()
@@ -151,7 +150,7 @@ contract GooStew is ERC20, Constants {
             + _computeUnmintedShares(_gobblerSharesPerMultipleIndex, gobblerDeposits[account].lastIndex, userSumMultiples);
     }
 
-    function _beforeTokenTransfer(address from, address /* to */, uint256 /* amount */) internal virtual override {
+    function _beforeTokenTransfer(address from, address, /* to */ uint256 /* amount */ ) internal virtual override {
         // as `balanceOf` reflects an optimistic balance, we need to update `from` here s.t. users can transfer entire balance.
         // `to` does not need to be updated because correctness of user's inflation update logic is based only on gobbler emissionMultiple, not on balance
         _updateInflation();
@@ -209,7 +208,10 @@ contract GooStew is ERC20, Constants {
     }
 
     /// redeems all gobblers of the caller
-    function redeemGobblers(uint256[] calldata removalIndexesDescending, uint256[] calldata expectedGobblerIds) external updateInflation {
+    function redeemGobblers(uint256[] calldata removalIndexesDescending, uint256[] calldata expectedGobblerIds)
+        external
+        updateInflation
+    {
         _updateUser(msg.sender);
 
         uint32 sumMultiples = 0;
@@ -240,7 +242,6 @@ contract GooStew is ERC20, Constants {
 
         _pushGoo(msg.sender, gooAmount);
     }
-
 
     /// @dev goo shares price denominated in goo: totalGoo * 1e18 / totalShares
     function _sharesPrice() internal view returns (uint256) {
@@ -289,14 +290,22 @@ contract GooStew is ERC20, Constants {
     /*//////////////////////////////////////////////////////////////
                         UTILITY VIEW FUNCTIONS
     //////////////////////////////////////////////////////////////*/
-    function getUserInfo(address user) external view returns (uint256[] memory gobblerIds, uint256 shares, uint32 sumMultiples, uint256 lastIndex) {
+    function getUserInfo(address user)
+        external
+        view
+        returns (uint256[] memory gobblerIds, uint256 shares, uint32 sumMultiples, uint256 lastIndex)
+    {
         shares = balanceOf(user);
         gobblerIds = gobblerDeposits[user].packedIds.getValues();
         sumMultiples = gobblerDeposits[user].sumMultiples;
         lastIndex = gobblerDeposits[user].lastIndex;
     }
 
-    function getGlobalInfo() external view returns (uint256 sharesTotalSupply, uint32 sumMultiples, uint64 lastUpdate, uint256 lastIndex, uint256 price) {
+    function getGlobalInfo()
+        external
+        view
+        returns (uint256 sharesTotalSupply, uint32 sumMultiples, uint64 lastUpdate, uint256 lastIndex, uint256 price)
+    {
         sharesTotalSupply = totalSupply;
         sumMultiples = _sumMultiples;
         lastUpdate = uint64(_lastUpdate);

--- a/src/GooStew.sol
+++ b/src/GooStew.sol
@@ -68,6 +68,7 @@ contract GooStew is ERC20, Constants {
         if (_lastUpdate == block.timestamp) return;
 
         (, uint256 rewardsGoo, uint256 rewardsGobblers) = _calculateUpdate();
+        _lastUpdate = block.timestamp; // update can now be set as following functions don't use it anymore
 
         // 1. update goo rewards: this updates _gooSharesPrice
         _totalGoo += rewardsGoo;
@@ -84,7 +85,6 @@ contract GooStew is ERC20, Constants {
             _gobblerSharesPerMultipleIndex += (mintShares * 1e18) / _sumMultiples;
         }
 
-        _lastUpdate = block.timestamp;
     }
 
     function _calculateUpdate()
@@ -161,7 +161,7 @@ contract GooStew is ERC20, Constants {
         // as `balanceOf` reflects an optimistic balance, we need to update `from` here s.t. users can transfer entire balance.
         // `to` does not need to be updated because correctness of user's inflation update logic is based only on gobbler emissionMultiple, not on balance
         _updateInflation();
-        if (from != address(0)) _updateUser(from);
+        _updateUser(from);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/LibGOO.sol
+++ b/src/LibGOO.sol
@@ -1,6 +1,6 @@
-// https://github.com/transmissions11/goo-issuance/blob/648e65e66e43ff5c19681427e300ece9c0df1437/src/LibGOO.sol#L1
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+// Base: https://github.com/transmissions11/goo-issuance/blob/648e65e66e43ff5c19681427e300ece9c0df1437/src/LibGOO.sol#L1
 
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 

--- a/src/LibPackedArray.sol
+++ b/src/LibPackedArray.sol
@@ -1,0 +1,211 @@
+// https://github.com/transmissions11/goo-issuance/blob/648e65e66e43ff5c19681427e300ece9c0df1437/src/LibGOO.sol#L1
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import "forge-std/console2.sol";
+
+/// @dev tighly packs values in range [1, 10_000] (max gobbler ID) into an array
+/// slots are filled with values from lsb to msb
+library LibPackedArray {
+    error ArrayLengthMismatch();
+    error ArrayNotSorted();
+    error ValueNotFound(uint256 value);
+
+    uint256 constant MAX_VALUE_BITS = 14; // log_2(10_000) = 13.82 bits < 14 bits;
+    uint256 constant VALUE_MASK = (2 ** MAX_VALUE_BITS) - 1; // MAX_VALUE_BITS-bit mask of 1's
+    uint256 constant MAX_VALUES_PER_SLOT = 256 / MAX_VALUE_BITS; // 256 slot bits / 14 MAX_VALUE_BITS = 18.25 ~ 18
+
+    /// @dev does NOT check if items already exist in the array
+    function add(uint256[] storage arr, uint256[] calldata values) internal {
+        uint256 valuesLength = values.length;
+        uint256 arrLength = arr.length;
+        // if there is no previous slot, act as if the previous slot was full which will create a new slot
+        uint256 lastSlot = arrLength == 0 ? type(uint256).max : arr[arrLength - 1];
+        uint256 valuesIndex = 0;
+
+        {
+            uint256 lastSlotUpdated = lastSlot;
+            // check if there's still space in lastSlot
+            for (uint256 i = 0; i < MAX_VALUES_PER_SLOT; ++i) {
+                uint256 value = _getValueAtIndex(lastSlot, i);
+                // if this condiition is true once, it'll be true until rest of loop. for readability reasons we keep it
+                if (value != 0) continue;
+                if (valuesIndex >= valuesLength) break;
+                lastSlotUpdated |= (values[valuesIndex++] & VALUE_MASK) << (i * MAX_VALUE_BITS);
+            }
+            // if they differ, lastSlot must have been a real slot
+            if (lastSlotUpdated != lastSlot) {
+                arr[arrLength - 1] = lastSlotUpdated;
+            }
+        }
+
+        // check if we can fill the previous slot
+        while (valuesIndex < valuesLength) {
+            uint256 newSlot = 0;
+            // fill slot with remaining values
+            for (uint256 i = 0; i < MAX_VALUES_PER_SLOT && valuesIndex < valuesLength; ++i) {
+                newSlot |= (values[valuesIndex++] & VALUE_MASK) << (i * MAX_VALUE_BITS);
+            }
+            arr.push(newSlot);
+        }
+    }
+
+    function remove(
+        uint256[] storage arr,
+        uint256[] calldata removalIndexesDesc,
+        uint256[] calldata expectedRemovedValues
+    )
+        external
+    {
+        if (removalIndexesDesc.length != expectedRemovedValues.length) {
+            revert ArrayLengthMismatch();
+        }
+        if (removalIndexesDesc.length == 0) {
+            return;
+        }
+        // ensure sorted in descending order (highest index to lowest)
+        for (uint256 i = 1; i < removalIndexesDesc.length; ++i) {
+            // require(removalIndexesDesc[i] < removalIndexesDesc[i - 1])
+            if (removalIndexesDesc[i] >= removalIndexesDesc[i - 1]) {
+                revert ArrayNotSorted();
+            }
+        }
+        uint256 arrLength = arr.length;
+        if (arrLength == 0) {
+            revert ValueNotFound(expectedRemovedValues[0]);
+        }
+
+        // at this point removalIndexesDesc.length > 0 && arrLength > 0
+        // 1. count the number of values in the last slot
+        uint256[] memory arrCopy = new uint256[](arrLength);
+        uint256 runningLastSlotIndex = arrLength - 1; // decreased by 1 whenever we remove the entire last slot
+        arrCopy[runningLastSlotIndex] = arr[runningLastSlotIndex];
+        uint256 currentNumValuesLastSlot = _countValues(arrCopy[runningLastSlotIndex]); // >= 1 as slot exists
+        console2.log("currentNumValuesLastSlot", currentNumValuesLastSlot);
+
+        // 2. cache only the slots that we're going to touch for removalIndexes (& last slot)
+        for (uint256 i = 0; i < removalIndexesDesc.length; ++i) {
+            uint256 slotIndex = removalIndexesDesc[i] / MAX_VALUES_PER_SLOT;
+            // prevent reading a slot twice. any slot in arr is non-zero as zero slots are removed
+            if (arrCopy[slotIndex] == 0) {
+                arrCopy[slotIndex] = arr[slotIndex];
+            }
+        }
+
+        // 3. now iterate over removals and remove value by swapping it with last value + "pop" last value
+        // we need to keep reading and writing to arrCopy each iteration as runningLastSlotIndex might be the same as slotIndex, which would then work on outdated data
+        for (uint256 i = 0; i < removalIndexesDesc.length; ++i) {
+            console2.log("=== iteration %s ===", i);
+            // a) read last value
+            uint256 lastSlot = arrCopy[runningLastSlotIndex];
+            uint256 lastValue = _getValueAtIndex(lastSlot, currentNumValuesLastSlot - 1);
+            console2.log("lastValue", lastValue);
+
+            // b) set new value
+            uint256 slotIndex = removalIndexesDesc[i] / MAX_VALUES_PER_SLOT;
+            uint256 valueIndex = removalIndexesDesc[i] % MAX_VALUES_PER_SLOT;
+            uint256 slot = arrCopy[slotIndex];
+            uint256 value = _getValueAtIndex(slot, valueIndex);
+            if (value != expectedRemovedValues[i]) revert ValueNotFound(expectedRemovedValues[i]);
+            console2.logBytes32(bytes32(slot));
+            slot = _setValueAtIndex(slot, valueIndex, lastValue);
+            console2.logBytes32(bytes32(slot));
+            // write it back to cache
+            arrCopy[slotIndex] = slot;
+
+            // c) set last value to zero. (this order works if index to remove is same index as runningLastSlotIndex)
+            lastSlot = arrCopy[runningLastSlotIndex];
+            console2.log("lastSlot");
+            console2.logBytes32(bytes32(lastSlot));
+            lastSlot = _setValueAtIndex(lastSlot, currentNumValuesLastSlot - 1, 0);
+            console2.logBytes32(bytes32(lastSlot));
+            // write it back
+            arrCopy[runningLastSlotIndex] = lastSlot;
+
+            // d) we swapped last value => decrement currentNumValuesLastSlot and adjust lastSlot config
+            if (--currentNumValuesLastSlot == 0) {
+                // we also need to decrement runningLastSlotIndex
+                if (runningLastSlotIndex == 0) {
+                    // require that this was the last iteration, `i >= removalIndexesDesc.length - 1`. otherwise outstanding removals
+                    if (i + 1 < removalIndexesDesc.length) {
+                        revert ValueNotFound(expectedRemovedValues[i + 1]);
+                    }
+                } else {
+                    // decrement and potentially read fresh slot from storage (if slot not fresh, it has been modified through a removal swap already)
+                    --runningLastSlotIndex;
+                    if (arrCopy[runningLastSlotIndex] == 0) {
+                        arrCopy[runningLastSlotIndex] = arr[runningLastSlotIndex];
+                    }
+                    currentNumValuesLastSlot = MAX_VALUES_PER_SLOT; // a lower-index slot is always full because we replace holes
+                }
+            }
+        }
+
+        // 4. write back all touched slots to storage
+        // handle special case that all items were removed (runningLastSlotIndex == 0 && currentNumValuesLastSlot == 0) above where we couldn't decrement runningLastSlotIndex
+        if (runningLastSlotIndex == 0 && currentNumValuesLastSlot == 0) {
+            console2.log("popping all special case");
+            for (uint256 i = 0; i < arrLength; i++) {
+                arr.pop();
+            }
+            return;
+        }
+
+        // runningLastSlotIndex is now accurate and points to a non-empty slot. pop all greater ones
+        for (uint256 i = arrLength - 1; i > runningLastSlotIndex; i--) {
+            console2.log("popping");
+            arr.pop();
+        }
+        // write runningLastSlotIndex
+        arr[runningLastSlotIndex] = arrCopy[runningLastSlotIndex];
+        delete arrCopy[runningLastSlotIndex];
+        // what's left are only the slots where values have been removed
+        for (uint256 i = 0; i < removalIndexesDesc.length; ++i) {
+            uint256 slotIndex = removalIndexesDesc[i] / MAX_VALUES_PER_SLOT;
+            // prevent writing a slot twice. a legitimately touched slot cannot be zero, only `i > runningLastSlotIndex` which have already been written
+            if (arrCopy[slotIndex] != 0) {
+                arr[slotIndex] = arrCopy[slotIndex];
+                delete arrCopy[slotIndex];
+            }
+        }
+    }
+
+    function getValues(uint256[] storage arr) internal view returns (uint256[] memory values) {
+        // count how many values are in the last slot
+        uint256 arrLength = arr.length;
+        if (arrLength == 0) {
+            return new uint256[](0);
+        }
+
+        // create copy of arr in memory as we need to iterate over all of them anyway
+        uint256[] memory _arr = arr;
+        uint256 lastSlot = _arr[arrLength - 1];
+        uint256 numValuesLastSlot = _countValues(lastSlot);
+
+        // all previous slots are full + number of values in last slot
+        uint256 valuesLength = MAX_VALUES_PER_SLOT * (arrLength - 1) + numValuesLastSlot;
+        values = new uint256[](valuesLength);
+
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            uint256 slotIndex = i / MAX_VALUES_PER_SLOT;
+            uint256 valueIndex = i % MAX_VALUES_PER_SLOT;
+            values[i] = _getValueAtIndex(_arr[slotIndex], valueIndex);
+        }
+    }
+
+    function _countValues(uint256 slot) private pure returns (uint256 numValues) {
+        for (; numValues < MAX_VALUES_PER_SLOT; ++numValues) {
+            uint256 value = _getValueAtIndex(slot, numValues);
+            if (value == 0) break;
+        }
+    }
+
+    function _getValueAtIndex(uint256 slot, uint256 index) private pure returns (uint256 value) {
+        value = (slot >> (index * MAX_VALUE_BITS)) & VALUE_MASK;
+    }
+
+    function _setValueAtIndex(uint256 slot, uint256 index, uint256 value) private pure returns (uint256 newSlot) {
+        newSlot = slot & ~((VALUE_MASK) << (index * MAX_VALUE_BITS)); // clear bits
+        newSlot |= (value & VALUE_MASK) << (index * MAX_VALUE_BITS); // set new bits
+    }
+}

--- a/src/LibPackedArray.sol
+++ b/src/LibPackedArray.sol
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import "forge-std/console2.sol";
-
 /// @dev tighly packs values in range [1, 10_000] (max gobbler ID) into an array
 /// slots are filled with values from lsb to msb
 library LibPackedArray {

--- a/src/LibPackedArray.sol
+++ b/src/LibPackedArray.sol
@@ -1,9 +1,9 @@
-// https://github.com/transmissions11/goo-issuance/blob/648e65e66e43ff5c19681427e300ece9c0df1437/src/LibGOO.sol#L1
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-/// @dev tighly packs values in range [1, 10_000] (max gobbler ID) into an array
-/// slots are filled with values from lsb to msb
+/// @title LibPackedArray
+/// @author cmichel
+/// @dev tighly packs values in range [1, 10_000] into an array. slots are filled with values from lsb to msb
 library LibPackedArray {
     error ArrayLengthMismatch();
     error ArrayNotSorted();
@@ -14,7 +14,7 @@ library LibPackedArray {
     uint256 constant VALUE_MASK = (2 ** MAX_VALUE_BITS) - 1; // MAX_VALUE_BITS-bit mask of 1's
     uint256 constant MAX_VALUES_PER_SLOT = 256 / MAX_VALUE_BITS; // 256 slot bits / 14 MAX_VALUE_BITS = 18.25 ~ 18
 
-    /// @dev does NOT check if items already exist in the array
+    /// @dev does NOT check if items already exist in the array. caller needs to ensure no duplicates can happen
     function add(uint256[] storage arr, uint256[] calldata values) internal {
         uint256 valuesLength = values.length;
         uint256 arrLength = arr.length;
@@ -49,6 +49,8 @@ library LibPackedArray {
         }
     }
 
+    /// @dev verifies that value at `removalIndexesDesc[i]` equals `expectedRemovedValues[i]` (and `expectedRemovedValues[i] != 0`).
+    /// this ensures that all values in `expectedRemovedValues` have indeed been found and removed
     function remove(
         uint256[] storage arr,
         uint256[] calldata removalIndexesDesc,
@@ -161,6 +163,7 @@ library LibPackedArray {
         }
     }
 
+    /// @dev unpacks the packed array into a normal array of values
     function getValues(uint256[] storage arr) internal view returns (uint256[] memory values) {
         // count how many values are in the last slot
         uint256 arrLength = arr.length;

--- a/test/GooStew.t.sol
+++ b/test/GooStew.t.sol
@@ -151,7 +151,9 @@ contract GooStewTest is BasicTest, Constants {
             console2.log("redeeming gobblers ...");
             uint256[] memory gobblerIds = new uint256[](1);
             gobblerIds[0] = gobblerId;
-            stew.redeemGobblers(gobblerIds);
+            uint256[] memory removalIndexes = new uint256[](1);
+            removalIndexes[0] = 0; // only have a single gobbler
+            stew.redeemGobblers(removalIndexes, gobblerIds);
         }
         console2.log("redeeming goo ...");
         uint256 gooAmount = stew.redeemGooShares(type(uint256).max);

--- a/test/GooStew.t.sol
+++ b/test/GooStew.t.sol
@@ -114,7 +114,6 @@ contract GooStewTest is BasicTest, Constants {
             stew.depositGoo(gooDeposits[1]);
         }
         vm.stopPrank();
-
         skip(delays[0]);
 
         // someone else deposits some multiple and goo again. time passes.
@@ -131,9 +130,7 @@ contract GooStewTest is BasicTest, Constants {
         skip(delays[1]);
 
         redeemAndAssertNoLoss(1, allGobblerIds[1], gobblerMultiples[1], gooDeposits[1], totalDelay);
-
         redeemAndAssertNoLoss(0, allGobblerIds[0], gobblerMultiples[0], gooDeposits[0], totalDelay);
-
         redeemAndAssertNoLoss(2, allGobblerIds[2], gobblerMultiples[2], gooDeposits[2], delays[1]);
     }
 
@@ -151,10 +148,12 @@ contract GooStewTest is BasicTest, Constants {
         vm.startPrank(_users[userId]);
 
         if (gobblerId > 0) {
+            console2.log("redeeming gobblers ...");
             uint256[] memory gobblerIds = new uint256[](1);
             gobblerIds[0] = gobblerId;
             stew.redeemGobblers(gobblerIds);
         }
+        console2.log("redeeming goo ...");
         uint256 gooAmount = stew.redeemGooShares(type(uint256).max);
         vm.stopPrank();
 

--- a/test/GooStew.t.sol
+++ b/test/GooStew.t.sol
@@ -13,14 +13,25 @@ import "./ArtGobblersTest.sol";
 
 contract BasicTest is ArtGobblersTest, ERC1155TokenReceiver {
     GooStew public stew;
+    address[] internal _users;
 
     function setUp() public virtual override {
+        _users.push(address(0x1000));
+        _users.push(address(0x1001));
+        _users.push(address(0x1002));
+
         super.setUp();
         stew = new GooStew(address(gobblers), address(goo));
 
         _mintGoo(address(this), type(uint128).max);
         goo.approve(address(stew), type(uint256).max);
         gobblers.setApprovalForAll(address(stew), true);
+        for (uint256 i = 0; i < _users.length; i++) {
+            vm.startPrank(_users[i]);
+            goo.approve(address(stew), type(uint256).max);
+            gobblers.setApprovalForAll(address(stew), true);
+            vm.stopPrank();
+        }
     }
 
     function xtestGobblerMint() public {
@@ -30,7 +41,7 @@ contract BasicTest is ArtGobblersTest, ERC1155TokenReceiver {
         uint256[] memory gobblerIds = new uint256[](2);
 
         for (uint256 i = 0; i < multiples.length; i++) {
-            gobblerIds[i] = gobblers.mintGobblerExposed(uint32(multiples[i]));
+            gobblerIds[i] = gobblers.mintGobblerExposed(address(this), uint32(multiples[i]));
             assertEq(gobblers.ownerOf(gobblerIds[i]), address(this));
             assertEq(gobblers.getGobblerEmissionMultiple(gobblerIds[i]), multiples[i]);
         }
@@ -49,9 +60,9 @@ contract GooStewTest is BasicTest, Constants {
      * user redeems, should have received at least as much as they would have received on their own
      */
     function testNoLoss(
+        uint24[2] memory delays, // in seconds, max range ~200 days
         uint16[3] memory gobblerMultiples,
-        uint72[3] memory gooDeposits,
-        uint24[2] memory delays // in seconds, max range ~200 days
+        uint72[3] memory gooDeposits
     )
         public
     {
@@ -61,7 +72,8 @@ contract GooStewTest is BasicTest, Constants {
         // lower-bound user goo deposits to not fuzz test with tiny values that lead to rounding errors.
         for (uint256 i = 0; i < gooDeposits.length; i++) {
             if (gooDeposits[i] > 0) {
-                gooDeposits[i] = uint72(bound(gooDeposits[0], MIN_GOO_SHARES_INITIAL_MINT, type(uint72).max));
+                gooDeposits[i] = uint72(bound(gooDeposits[0], 1e18, type(uint72).max));
+                goo.transfer(_users[i], gooDeposits[i]);
             }
         }
 
@@ -70,68 +82,64 @@ contract GooStewTest is BasicTest, Constants {
         uint256[] memory allGobblerIds = new uint256[](gobblerMultiples.length);
         for (uint256 i = 0; i < gobblerMultiples.length; i++) {
             if (gobblerMultiples[i] > 0) {
-                allGobblerIds[i] = gobblers.mintGobblerExposed(gobblerMultiples[i]);
+                allGobblerIds[i] = gobblers.mintGobblerExposed(_users[i], gobblerMultiples[i]);
             }
         }
         uint256[] memory gobblerIds = new uint256[](1);
-        uint256[] memory stakingIds = new uint256[](3);
-        uint256[] memory gooShareAmounts = new uint256[](3);
 
         // deposit initial mint that is sent to burn address because first deposit can actually lead to a loss
         // in practice we will bootstrap the contract with this tiny amount of goo
-        stew.deposit(new uint256[](0), MIN_GOO_SHARES_INITIAL_MINT);
+        stew.depositGoo(MIN_GOO_SHARES_INITIAL_MINT);
 
         // someone deposits some multiple and goo
         console2.log("===== User 0 =====");
+        vm.startPrank(_users[0]);
         gobblerIds[0] = allGobblerIds[0];
         {
-            (uint256 stakingId,, uint256 gooShares) =
-                stew.deposit(gobblerIds[0] > 0 ? gobblerIds : new uint256[](0), gooDeposits[0]);
-            stakingIds[0] = stakingId;
-            gooShareAmounts[0] = gooShares;
+            if (gobblerIds[0] > 0) {
+                stew.depositGobblers(gobblerIds);
+            }
+            stew.depositGoo(gooDeposits[0]);
         }
+        vm.stopPrank();
 
         // user deposits some multiple and some goo. time passes.
         console2.log("===== User 1 =====");
+        vm.startPrank(_users[1]);
         gobblerIds[0] = allGobblerIds[1];
         {
-            (uint256 stakingId,, uint256 gooShares) =
-                stew.deposit(gobblerIds[0] > 0 ? gobblerIds : new uint256[](0), gooDeposits[1]);
-            stakingIds[1] = stakingId;
-            gooShareAmounts[1] = gooShares;
+            if (gobblerIds[0] > 0) {
+                stew.depositGobblers(gobblerIds);
+            }
+            stew.depositGoo(gooDeposits[1]);
         }
+        vm.stopPrank();
 
         skip(delays[0]);
 
         // someone else deposits some multiple and goo again. time passes.
         console2.log("===== User 2 =====");
+        vm.startPrank(_users[2]);
         gobblerIds[0] = allGobblerIds[2];
         {
-            (uint256 stakingId,, uint256 gooShares) =
-                stew.deposit(gobblerIds[0] > 0 ? gobblerIds : new uint256[](0), gooDeposits[2]);
-            stakingIds[2] = stakingId;
-            gooShareAmounts[2] = gooShares;
+            if (gobblerIds[0] > 0) {
+                stew.depositGobblers(gobblerIds);
+            }
+            stew.depositGoo(gooDeposits[2]);
         }
+        vm.stopPrank();
         skip(delays[1]);
 
-        redeemAndAssertNoLoss(
-            1, allGobblerIds[1], gooShareAmounts[1], stakingIds[1], gobblerMultiples[1], gooDeposits[1], totalDelay
-        );
+        redeemAndAssertNoLoss(1, allGobblerIds[1], gobblerMultiples[1], gooDeposits[1], totalDelay);
 
-        redeemAndAssertNoLoss(
-            0, allGobblerIds[0], gooShareAmounts[0], stakingIds[0], gobblerMultiples[0], gooDeposits[0], totalDelay
-        );
+        redeemAndAssertNoLoss(0, allGobblerIds[0], gobblerMultiples[0], gooDeposits[0], totalDelay);
 
-        redeemAndAssertNoLoss(
-            2, allGobblerIds[2], gooShareAmounts[2], stakingIds[2], gobblerMultiples[2], gooDeposits[2], delays[1]
-        );
+        redeemAndAssertNoLoss(2, allGobblerIds[2], gobblerMultiples[2], gooDeposits[2], delays[1]);
     }
 
     function redeemAndAssertNoLoss(
         uint256 userId,
         uint256 gobblerId,
-        uint256 gooShares,
-        uint256 stakingId,
         uint256 gobblerMultiple,
         uint256 gooDepositAmount,
         uint256 delay
@@ -140,12 +148,15 @@ contract GooStewTest is BasicTest, Constants {
     {
         // user redeems, should have received at least as much as they would have received on their own
         console2.log("===== Redeem User %s =====", userId);
-        uint256[] memory gobblerIds = new uint256[](1);
-        gobblerIds[0] = gobblerId;
-        uint256 gooAmount = stew.redeemGooShares(gooShares);
-        if (stakingId > 0) {
-            gooAmount += stew.redeemGobblers(stakingId, gobblerIds);
+        vm.startPrank(_users[userId]);
+
+        if (gobblerId > 0) {
+            uint256[] memory gobblerIds = new uint256[](1);
+            gobblerIds[0] = gobblerId;
+            stew.redeemGobblers(gobblerIds);
         }
+        uint256 gooAmount = stew.redeemGooShares(type(uint256).max);
+        vm.stopPrank();
 
         uint256 totalGooNoStake = LibGOO.computeGOOBalance(
             gobblerMultiple,

--- a/test/LibPackedArray.t.sol
+++ b/test/LibPackedArray.t.sol
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "forge-std/console2.sol";
+import {LibPackedArray} from "src/LibPackedArray.sol";
+
+// create wrapper so we can work with calldata
+contract PackedArray {
+    using LibPackedArray for uint256[];
+
+    uint256[] internal _arr;
+
+    function add(uint256[] calldata values) external {
+        _arr.add(values);
+    }
+
+    function remove(
+        uint256[] calldata removalIndexesDesc,
+        uint256[] calldata expectedRemovedValues
+    ) external {
+        _arr.remove(removalIndexesDesc, expectedRemovedValues);
+    }
+
+    function getValues() external view returns (uint256[] memory values) {
+        return _arr.getValues();
+    }
+}
+
+contract SimpleArray {
+    uint256[] internal _arr;
+
+    function add(uint256[] calldata values) external {
+        for (uint256 i = 0; i < values.length; ++i) {
+            _arr.push(values[i]);
+        }
+    }
+
+    function remove(
+        uint256[] calldata removalIndexesDesc,
+        uint256[] calldata expectedRemovedValues
+    ) external {
+        require(
+            removalIndexesDesc.length == expectedRemovedValues.length,
+            "!length"
+        );
+        for (uint256 i = 1; i < removalIndexesDesc.length; ++i) {
+            require(
+                removalIndexesDesc[i] < removalIndexesDesc[i - 1],
+                "!sorted"
+            );
+        }
+
+        for (uint256 i = 0; i < removalIndexesDesc.length; ++i) {
+            // we always remove from the back so we don't need to adjust the index
+            require(
+                _arr[removalIndexesDesc[i]] == expectedRemovedValues[i],
+                "!valueEqual"
+            );
+            _arr[removalIndexesDesc[i]] = _arr[_arr.length - 1];
+            _arr.pop();
+        }
+    }
+
+    function getValues() external view returns (uint256[] memory values) {
+        return _arr;
+    }
+}
+
+contract RandomDrawTest is Test {
+    uint256[] private values;
+    uint256[] private indexes;
+    uint256 private valuesDrawSeed;
+    uint256 private indexesDrawSeed;
+
+    function resetValues(
+        uint256 minInclusive,
+        uint256 maxInclusive,
+        uint256 seed
+    ) internal {
+        delete values;
+        for (uint256 i = minInclusive; i <= maxInclusive; ++i) {
+            values.push(i);
+        }
+        valuesDrawSeed = seed;
+    }
+
+    function drawUniqueValue() internal returns (uint256 value) {
+        assert(values.length > 0);
+
+        uint256 valuesIndex = uint256(
+            keccak256(abi.encodePacked(valuesDrawSeed, uint256(0)))
+        ) % values.length;
+        value = values[valuesIndex];
+        values[valuesIndex] = values[values.length - 1];
+        values.pop();
+
+        valuesDrawSeed = uint256(keccak256(abi.encodePacked(valuesDrawSeed)));
+    }
+
+    function resetIndexes(
+        uint256 minInclusive,
+        uint256 maxInclusive,
+        uint256 seed
+    ) internal {
+        delete indexes;
+        for (uint256 i = minInclusive; i <= maxInclusive; ++i) {
+            indexes.push(i);
+        }
+        indexesDrawSeed = seed;
+    }
+
+    function drawUniqueIndex() internal returns (uint256 value) {
+        assert(indexes.length > 0);
+
+        uint256 indexesIndex = uint256(
+            keccak256(abi.encodePacked(indexesDrawSeed, uint256(1)))
+        ) % indexes.length;
+        value = indexes[indexesIndex];
+        indexes[indexesIndex] = indexes[indexes.length - 1];
+        indexes.pop();
+
+        indexesDrawSeed = uint256(keccak256(abi.encodePacked(indexesDrawSeed)));
+    }
+
+    function sort(uint256[] memory arr) public pure {
+        if (arr.length > 0) {
+            quickSort(arr, 0, arr.length - 1);
+        }
+    }
+
+    function quickSort(
+        uint256[] memory arr,
+        uint256 left,
+        uint256 right
+    ) public pure {
+        if (left >= right) {
+            return;
+        }
+        uint256 p = arr[(left + right) / 2]; // p = the pivot element
+        uint256 i = left;
+        uint256 j = right;
+        while (i < j) {
+            while (arr[i] > p) ++i;
+            while (arr[j] < p) --j; // arr[j] > p means p still to the left, so j > 0
+            if (arr[i] < arr[j]) {
+                (arr[i], arr[j]) = (arr[j], arr[i]);
+            } else {
+                ++i;
+            }
+        }
+
+        // Note --j was only done when a[j] > p.  So we know: a[j] == p, a[<j] <= p, a[>j] > p
+        if (j > left) {
+            quickSort(arr, left, j - 1);
+        } // j > left, so j > 0
+        quickSort(arr, j + 1, right);
+    }
+}
+
+contract PackedArrayDifferentialFuzzTest is RandomDrawTest {
+    PackedArray p;
+    SimpleArray s;
+
+    function setUp() public virtual {
+        p = new PackedArray();
+        s = new SimpleArray();
+    }
+
+    function testAddValuesSingle(uint256 seed, uint16 _length) public {
+        resetValues(1, 10_000, seed);
+
+        uint256 length = bound(_length, 0, 1_000);
+        uint256[] memory values = new uint256[](length);
+        for (uint256 i = 0; i < length; i++) {
+            values[i] = drawUniqueValue();
+        }
+
+        p.add(values);
+        s.add(values);
+        uint256[] memory received = p.getValues();
+        uint256[] memory expected = s.getValues();
+
+        assertEq(received.length, expected.length, "length mismatch");
+        assertEq(
+            keccak256(abi.encodePacked(received)),
+            keccak256(abi.encodePacked(expected)),
+            "value mismatch"
+        );
+    }
+
+    function testAddValuesMultiple(uint256 seed, uint16 _length) public {
+        resetValues(1, 10_000, seed);
+
+        uint256 length = bound(_length, 0, 1_000);
+        for (uint256 i = 0; i < length; i++) {
+            uint256[] memory values = new uint256[](1);
+            values[0] = drawUniqueValue();
+            p.add(values);
+            s.add(values);
+        }
+
+        uint256[] memory received = p.getValues();
+        uint256[] memory expected = s.getValues();
+
+        assertEq(received.length, expected.length, "length mismatch");
+        assertEq(
+            keccak256(abi.encodePacked(received)),
+            keccak256(abi.encodePacked(expected)),
+            "value mismatch"
+        );
+    }
+
+    function testRemoveValuesSingle(
+        uint256 seed,
+        uint16 _length,
+        uint16 _removeLength
+    ) public {
+        uint256 length = bound(_length, 1, 1_000); // at least length of 1
+        uint256 removeLength = bound(_removeLength, 0, length);
+        resetValues(1, 10_000, seed);
+        resetIndexes(0, length - 1, seed);
+
+        uint256[] memory values = new uint256[](length);
+        for (uint256 i = 0; i < length; i++) {
+            values[i] = drawUniqueValue();
+        }
+
+        uint256[] memory removalIndexes = new uint256[](removeLength);
+        uint256[] memory removalValues = new uint256[](removeLength);
+        for (uint256 i = 0; i < removeLength; i++) {
+            removalIndexes[i] = drawUniqueIndex();
+        }
+        sort(removalIndexes);
+        for (uint256 i = 0; i < removeLength; i++) {
+            removalValues[i] = values[removalIndexes[i]];
+        }
+
+        s.add(values);
+        p.add(values);
+        s.remove(removalIndexes, removalValues);
+        p.remove(removalIndexes, removalValues);
+
+        uint256[] memory received = p.getValues();
+        uint256[] memory expected = s.getValues();
+
+        assertEq(received.length, expected.length, "length mismatch");
+        assertEq(
+            keccak256(abi.encodePacked(received)),
+            keccak256(abi.encodePacked(expected)),
+            "value mismatch"
+        );
+    }
+
+    function testRemoveValuesMultiple(
+        uint256 seed,
+        uint16 _length,
+        uint16 _removeLength
+    ) public {
+        uint256 length = bound(_length, 1, 1_000); // at least length of 1
+        uint256 removeLength = bound(_removeLength, 0, length);
+        resetValues(1, 10_000, seed);
+        resetIndexes(0, length - 1, seed);
+
+        uint256[] memory values = new uint256[](length);
+        for (uint256 i = 0; i < length; i++) {
+            values[i] = drawUniqueValue();
+        }
+
+        uint256[] memory removalIndexes = new uint256[](removeLength);
+        uint256[] memory removalValues = new uint256[](removeLength);
+        for (uint256 i = 0; i < removeLength; i++) {
+            removalIndexes[i] = drawUniqueIndex();
+        }
+        sort(removalIndexes);
+        for (uint256 i = 0; i < removeLength; i++) {
+            removalValues[i] = values[removalIndexes[i]];
+        }
+
+        s.add(values);
+        p.add(values);
+        for (uint256 i = 0; i < removeLength; i++) {
+            // the descending order of removalIndexes also makes single calls work correctly
+            uint256[] memory tmpIndexes = new uint256[](1);
+            uint256[] memory tmpValues = new uint256[](1);
+            tmpIndexes[0] = removalIndexes[i];
+            tmpValues[0] = removalValues[i];
+            s.remove(tmpIndexes, tmpValues);
+            p.remove(tmpIndexes, tmpValues);
+        }
+
+        uint256[] memory received = p.getValues();
+        uint256[] memory expected = s.getValues();
+
+        assertEq(received.length, expected.length, "length mismatch");
+        assertEq(
+            keccak256(abi.encodePacked(received)),
+            keccak256(abi.encodePacked(expected)),
+            "value mismatch"
+        );
+    }
+
+    function testAddRemoveMixed(
+        uint256[3] memory seeds,
+        uint16[3] memory _lengths,
+        uint16[3] memory _removeLengths
+    ) public {
+        resetValues(1, 10_000, seeds[0]);
+        for (uint256 iterations = 0; iterations < 3; ++iterations) {
+            uint256 length = bound(_lengths[iterations], 1, 1_000); // at least length of 1
+            uint256 removeLength = bound(_removeLengths[iterations], 0, length);
+
+            // 1. additions
+            uint256[] memory values = new uint256[](length);
+            for (uint256 i = 0; i < length; i++) {
+                values[i] = drawUniqueValue();
+            }
+            s.add(values);
+            p.add(values);
+
+            // checks
+            uint256[] memory expected = s.getValues();
+            uint256[] memory received = p.getValues();
+            {
+                assertEq(received.length, expected.length, "length mismatch");
+                assertEq(
+                    keccak256(abi.encodePacked(received)),
+                    keccak256(abi.encodePacked(expected)),
+                    "value mismatch"
+                );
+            }
+
+            // 2. removals
+            // choose fresh random indexes over the _entire_ current values
+            uint256 currentPackedArrayLength = s.getValues().length;
+            resetIndexes(0, currentPackedArrayLength - 1, seeds[iterations]);
+
+            uint256[] memory removalIndexes = new uint256[](removeLength);
+            uint256[] memory removalValues = new uint256[](removeLength);
+            for (uint256 i = 0; i < removeLength; i++) {
+                removalIndexes[i] = drawUniqueIndex();
+            }
+            sort(removalIndexes);
+            for (uint256 i = 0; i < removeLength; i++) {
+                removalValues[i] = expected[removalIndexes[i]];
+            }
+
+            s.remove(removalIndexes, removalValues);
+            p.remove(removalIndexes, removalValues);
+
+            // checks
+            {
+                received = p.getValues();
+                expected = s.getValues();
+                assertEq(received.length, expected.length, "length mismatch");
+                assertEq(
+                    keccak256(abi.encodePacked(received)),
+                    keccak256(abi.encodePacked(expected)),
+                    "value mismatch"
+                );
+            }
+        }
+    }
+}

--- a/test/LibPackedArray.t.sol
+++ b/test/LibPackedArray.t.sol
@@ -15,10 +15,7 @@ contract PackedArray {
         _arr.add(values);
     }
 
-    function remove(
-        uint256[] calldata removalIndexesDesc,
-        uint256[] calldata expectedRemovedValues
-    ) external {
+    function remove(uint256[] calldata removalIndexesDesc, uint256[] calldata expectedRemovedValues) external {
         _arr.remove(removalIndexesDesc, expectedRemovedValues);
     }
 
@@ -36,27 +33,15 @@ contract SimpleArray {
         }
     }
 
-    function remove(
-        uint256[] calldata removalIndexesDesc,
-        uint256[] calldata expectedRemovedValues
-    ) external {
-        require(
-            removalIndexesDesc.length == expectedRemovedValues.length,
-            "!length"
-        );
+    function remove(uint256[] calldata removalIndexesDesc, uint256[] calldata expectedRemovedValues) external {
+        require(removalIndexesDesc.length == expectedRemovedValues.length, "!length");
         for (uint256 i = 1; i < removalIndexesDesc.length; ++i) {
-            require(
-                removalIndexesDesc[i] < removalIndexesDesc[i - 1],
-                "!sorted"
-            );
+            require(removalIndexesDesc[i] < removalIndexesDesc[i - 1], "!sorted");
         }
 
         for (uint256 i = 0; i < removalIndexesDesc.length; ++i) {
             // we always remove from the back so we don't need to adjust the index
-            require(
-                _arr[removalIndexesDesc[i]] == expectedRemovedValues[i],
-                "!valueEqual"
-            );
+            require(_arr[removalIndexesDesc[i]] == expectedRemovedValues[i], "!valueEqual");
             _arr[removalIndexesDesc[i]] = _arr[_arr.length - 1];
             _arr.pop();
         }
@@ -73,11 +58,7 @@ contract RandomDrawTest is Test {
     uint256 private valuesDrawSeed;
     uint256 private indexesDrawSeed;
 
-    function resetValues(
-        uint256 minInclusive,
-        uint256 maxInclusive,
-        uint256 seed
-    ) internal {
+    function resetValues(uint256 minInclusive, uint256 maxInclusive, uint256 seed) internal {
         delete values;
         for (uint256 i = minInclusive; i <= maxInclusive; ++i) {
             values.push(i);
@@ -88,9 +69,7 @@ contract RandomDrawTest is Test {
     function drawUniqueValue() internal returns (uint256 value) {
         assert(values.length > 0);
 
-        uint256 valuesIndex = uint256(
-            keccak256(abi.encodePacked(valuesDrawSeed, uint256(0)))
-        ) % values.length;
+        uint256 valuesIndex = uint256(keccak256(abi.encodePacked(valuesDrawSeed, uint256(0)))) % values.length;
         value = values[valuesIndex];
         values[valuesIndex] = values[values.length - 1];
         values.pop();
@@ -98,11 +77,7 @@ contract RandomDrawTest is Test {
         valuesDrawSeed = uint256(keccak256(abi.encodePacked(valuesDrawSeed)));
     }
 
-    function resetIndexes(
-        uint256 minInclusive,
-        uint256 maxInclusive,
-        uint256 seed
-    ) internal {
+    function resetIndexes(uint256 minInclusive, uint256 maxInclusive, uint256 seed) internal {
         delete indexes;
         for (uint256 i = minInclusive; i <= maxInclusive; ++i) {
             indexes.push(i);
@@ -113,9 +88,7 @@ contract RandomDrawTest is Test {
     function drawUniqueIndex() internal returns (uint256 value) {
         assert(indexes.length > 0);
 
-        uint256 indexesIndex = uint256(
-            keccak256(abi.encodePacked(indexesDrawSeed, uint256(1)))
-        ) % indexes.length;
+        uint256 indexesIndex = uint256(keccak256(abi.encodePacked(indexesDrawSeed, uint256(1)))) % indexes.length;
         value = indexes[indexesIndex];
         indexes[indexesIndex] = indexes[indexes.length - 1];
         indexes.pop();
@@ -129,11 +102,7 @@ contract RandomDrawTest is Test {
         }
     }
 
-    function quickSort(
-        uint256[] memory arr,
-        uint256 left,
-        uint256 right
-    ) public pure {
+    function quickSort(uint256[] memory arr, uint256 left, uint256 right) public pure {
         if (left >= right) {
             return;
         }
@@ -182,11 +151,7 @@ contract PackedArrayDifferentialFuzzTest is RandomDrawTest {
         uint256[] memory expected = s.getValues();
 
         assertEq(received.length, expected.length, "length mismatch");
-        assertEq(
-            keccak256(abi.encodePacked(received)),
-            keccak256(abi.encodePacked(expected)),
-            "value mismatch"
-        );
+        assertEq(keccak256(abi.encodePacked(received)), keccak256(abi.encodePacked(expected)), "value mismatch");
     }
 
     function testAddValuesMultiple(uint256 seed, uint16 _length) public {
@@ -204,18 +169,10 @@ contract PackedArrayDifferentialFuzzTest is RandomDrawTest {
         uint256[] memory expected = s.getValues();
 
         assertEq(received.length, expected.length, "length mismatch");
-        assertEq(
-            keccak256(abi.encodePacked(received)),
-            keccak256(abi.encodePacked(expected)),
-            "value mismatch"
-        );
+        assertEq(keccak256(abi.encodePacked(received)), keccak256(abi.encodePacked(expected)), "value mismatch");
     }
 
-    function testRemoveValuesSingle(
-        uint256 seed,
-        uint16 _length,
-        uint16 _removeLength
-    ) public {
+    function testRemoveValuesSingle(uint256 seed, uint16 _length, uint16 _removeLength) public {
         uint256 length = bound(_length, 1, 1_000); // at least length of 1
         uint256 removeLength = bound(_removeLength, 0, length);
         resetValues(1, 10_000, seed);
@@ -245,18 +202,10 @@ contract PackedArrayDifferentialFuzzTest is RandomDrawTest {
         uint256[] memory expected = s.getValues();
 
         assertEq(received.length, expected.length, "length mismatch");
-        assertEq(
-            keccak256(abi.encodePacked(received)),
-            keccak256(abi.encodePacked(expected)),
-            "value mismatch"
-        );
+        assertEq(keccak256(abi.encodePacked(received)), keccak256(abi.encodePacked(expected)), "value mismatch");
     }
 
-    function testRemoveValuesMultiple(
-        uint256 seed,
-        uint16 _length,
-        uint16 _removeLength
-    ) public {
+    function testRemoveValuesMultiple(uint256 seed, uint16 _length, uint16 _removeLength) public {
         uint256 length = bound(_length, 1, 1_000); // at least length of 1
         uint256 removeLength = bound(_removeLength, 0, length);
         resetValues(1, 10_000, seed);
@@ -293,18 +242,12 @@ contract PackedArrayDifferentialFuzzTest is RandomDrawTest {
         uint256[] memory expected = s.getValues();
 
         assertEq(received.length, expected.length, "length mismatch");
-        assertEq(
-            keccak256(abi.encodePacked(received)),
-            keccak256(abi.encodePacked(expected)),
-            "value mismatch"
-        );
+        assertEq(keccak256(abi.encodePacked(received)), keccak256(abi.encodePacked(expected)), "value mismatch");
     }
 
-    function testAddRemoveMixed(
-        uint256[3] memory seeds,
-        uint16[3] memory _lengths,
-        uint16[3] memory _removeLengths
-    ) public {
+    function testAddRemoveMixed(uint256[3] memory seeds, uint16[3] memory _lengths, uint16[3] memory _removeLengths)
+        public
+    {
         resetValues(1, 10_000, seeds[0]);
         for (uint256 iterations = 0; iterations < 3; ++iterations) {
             uint256 length = bound(_lengths[iterations], 1, 1_000); // at least length of 1
@@ -323,11 +266,7 @@ contract PackedArrayDifferentialFuzzTest is RandomDrawTest {
             uint256[] memory received = p.getValues();
             {
                 assertEq(received.length, expected.length, "length mismatch");
-                assertEq(
-                    keccak256(abi.encodePacked(received)),
-                    keccak256(abi.encodePacked(expected)),
-                    "value mismatch"
-                );
+                assertEq(keccak256(abi.encodePacked(received)), keccak256(abi.encodePacked(expected)), "value mismatch");
             }
 
             // 2. removals
@@ -353,11 +292,7 @@ contract PackedArrayDifferentialFuzzTest is RandomDrawTest {
                 received = p.getValues();
                 expected = s.getValues();
                 assertEq(received.length, expected.length, "length mismatch");
-                assertEq(
-                    keccak256(abi.encodePacked(received)),
-                    keccak256(abi.encodePacked(expected)),
-                    "value mismatch"
-                );
+                assertEq(keccak256(abi.encodePacked(received)), keccak256(abi.encodePacked(expected)), "value mismatch");
             }
         }
     }

--- a/test/MockArtGobblers.sol
+++ b/test/MockArtGobblers.sol
@@ -25,16 +25,16 @@ contract MockArtGobblers is ArtGobblers {
     {}
 
     /// acts like calling `claimGobbler` + `revealGobblers(1)` + sets custom emission multiple
-    function mintGobblerExposed(uint32 emissionMultiple) external returns (uint256 gobblerId) {
+    function mintGobblerExposed(address to, uint32 emissionMultiple) external returns (uint256 gobblerId) {
         gobblerId = ++currentNonLegendaryId;
-        _mint(msg.sender, gobblerId);
+        _mint(to, gobblerId);
         gobblerRevealsData.waitingForSeed = false;
         gobblerRevealsData.toBeRevealed = uint56(1);
         gobblerRevealsData.lastRevealedId = uint56(gobblerId - 1);
         this.revealGobblers(1);
 
-        getUserData[msg.sender].emissionMultiple -= uint32(getGobblerData[gobblerId].emissionMultiple);
+        getUserData[to].emissionMultiple -= uint32(getGobblerData[gobblerId].emissionMultiple);
         getGobblerData[gobblerId].emissionMultiple = emissionMultiple;
-        getUserData[msg.sender].emissionMultiple += uint32(getGobblerData[gobblerId].emissionMultiple);
+        getUserData[to].emissionMultiple += uint32(getGobblerData[gobblerId].emissionMultiple);
     }
 }


### PR DESCRIPTION
See #3:

## Changelog

- make it an erc20permit issuing ibGoo
- add batch calls, split deposit into goo and gobblers, add a claim (`updateUser`) and a view balance function (`balanceOf`). (as we're doing an erc20 it'll do the balance storage slot + optimistic update on the inflation until last global update.)
- gobbler accounting on a per account level, remove ERC1155 and staking NFT. store deposited gobbler ids for address in a packed way. Can store up to 18 gobblers in a single storage slot. Redemption is also efficient given off-chain computed indexes.