### PR TITLE
Implement delay-mint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out/
 
 # Dotenv file
 .env
+.gas-snapshot

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ libs = ['lib']
 via_ir = false # avoid stack too deep and use optimizations
 optimizer_runs = 1000000
 bytecode_hash = "none"
-verbosity = 0
+verbosity = 2
 
 gas_reports = ['GooStew']
 

--- a/src/Constants.sol
+++ b/src/Constants.sol
@@ -13,4 +13,5 @@ abstract contract Constants {
 
     event DepositGobblers(address indexed owner, uint256[] gobblerIds, uint32 sumMultiples);
     event DepositGoo(address indexed owner, uint256 amount, uint256 shares);
+    event InflationUpdate(uint40 timestamp, uint256 rewardsGoo, uint256 rewardsGobblers, uint256 rewardsFee);
 }

--- a/src/Constants.sol
+++ b/src/Constants.sol
@@ -5,7 +5,6 @@ abstract contract Constants {
     uint256 public constant MIN_GOO_SHARES_INITIAL_MINT = 1e12;
     // solmate prevents us from minting to 0 address
     address internal constant BURN_ADDRESS = address(0xdeaDDeADDEaDdeaDdEAddEADDEAdDeadDEADDEaD);
-    address internal constant LAZY_MINT_ADDRESS = address(0x1);
 
     error Unauthorized();
     error InvalidArguments();

--- a/src/GooStew.sol
+++ b/src/GooStew.sol
@@ -129,6 +129,12 @@ contract GooStew is ERC20, BoringBatchable, Constants {
         // set cached values
         _totalGoo = totalGoo;
         // totalShares already set in _mint
+        emit InflationUpdate({
+            timestamp: uint40(block.timestamp), // safe for human years
+            rewardsGoo: rewardsGoo,
+            rewardsGobblers: rewardsGobblers,
+            rewardsFee: rewardsFee
+        });
     }
 
     function _calculateUpdate(uint256 lastTotalGoo, uint64 lastUpdate, uint32 sumMultiples, uint32 feePercentage)

--- a/test/GooStew.t.sol
+++ b/test/GooStew.t.sol
@@ -82,15 +82,14 @@ contract GooStewManualTest is BasicTest, Constants {
         stew.updateUser(address(0)); // trigger update for share price increase
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        assertEq(logs.length, 3, "unexpected events length"); // two Transfers, InflationUpdate
+        assertEq(logs.length, 2, "unexpected events length"); // 1 Transfer to fee address, 1 InflationUpdate
         Vm.Log memory log = logs[logs.length - 1];
         assertEq(log.topics[0], keccak256("InflationUpdate(uint40,uint256,uint256,uint256)"), "unexpected event");
-        (, , , uint256 rewardsFee) =
-            abi.decode(log.data, (uint40, uint256, uint256, uint256));
+        (,,, uint256 rewardsFee) = abi.decode(log.data, (uint40, uint256, uint256, uint256));
 
         vm.prank(feeRecipient);
         uint256 gooFees = stew.redeemGooShares(type(uint256).max);
-        assertApproxEqRel(gooFees, rewardsFee, 1e6 /* 1e-12 max error */);
+        assertApproxEqRel(gooFees, rewardsFee, 1e6 /* 1e-12 max error */ );
     }
 
     function testGobblersRedeem() public {


### PR DESCRIPTION
- refactors core `updateInflation` logic into a view function to prepare for correctly simulating updates in view functions like `balanceOf`
- Optimization: implements delayed mint. we don't mind to a `LAZY_MINT_ADDRESS` anymore in `updateInflation`, we only increase the `totalSupply`. This saves a `balanceOf[LAZY_MINT_ADDRESS]` update on the hot path.

Correct gas test for the Benchmark tests:

```
testBalanceOf() (gas: -2 (-0.016%)) 
testGetUserInfo() (gas: -32 (-0.071%)) 
testSharesPrice() (gas: 10 (0.101%)) 
testGetGlobalInfo() (gas: -25 (-0.171%)) 
testRedeemGobblers() (gas: -5538 (-1.827%)) 
testRedeemGobbler() (gas: -5502 (-5.102%)) 
testRedeemGooShares() (gas: -5498 (-6.367%)) 
testDepositGobblersInitial() (gas: -22150 (-6.639%)) 
testUpdate() (gas: -5489 (-9.646%)) 
testDepositGobblerInitial() (gas: -22114 (-12.877%)) 
testDepositGooInitial() (gas: -22110 (-15.676%)) 
testTransfer() (gas: 16365 (27.327%)) 
Overall gas change: -72085 (-30.964%)
```